### PR TITLE
HTTP/2 Test Failure

### DIFF
--- a/servlet/http2/pom.xml
+++ b/servlet/http2/pom.xml
@@ -27,6 +27,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-http-client-transport</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-common</artifactId>
             <version>${jetty-version}</version>
             <scope>test</scope>
@@ -432,7 +438,78 @@
                 <alpn.version>8.1.13.v20181017</alpn.version>
             </properties>
         </profile>
-
+        <profile>
+            <id>alpn-when-jdk8_211</id>
+            <activation>
+                <jdk>1.8.0_211</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_212</id>
+            <activation>
+                <jdk>1.8.0_212</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_221</id>
+            <activation>
+                <jdk>1.8.0_221</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_222</id>
+            <activation>
+                <jdk>1.8.0_222</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_231</id>
+            <activation>
+                <jdk>1.8.0_231</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_232</id>
+            <activation>
+                <jdk>1.8.0_232</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_241</id>
+            <activation>
+                <jdk>1.8.0_241</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>alpn-when-jdk8_242</id>
+            <activation>
+                <jdk>1.8.0_242</jdk>
+            </activation>
+            <properties>
+                <alpn.version>8.1.13.v20181017</alpn.version>
+            </properties>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
The HTTP/2 test no longer worked for the control group, as the akamai
website removed the header used in the test. The only way to fix this
test was to use the Jetty client directly, as this allows finding the
protocol used.