### PR TITLE
FISH-8086 - fix http2 test

### DIFF
--- a/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
+++ b/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
@@ -44,7 +44,7 @@ public class Http2Test {
      */
     @Test(timeout = 10000L)
     public void testHttp2ControlGroup() throws Exception {
-        testHttp2(new URI("https://http2.akamai.com/"));
+        testHttp2(new URI("https://linkedin.com/"));
     }
 
     /**


### PR DESCRIPTION
the test was pointing at https://http2.akamai.com to test for requests using http2 protocol. That website doesn't use http2 (anymore?), so I am replacing the url with https://linkedin.com. In the future, we shall have our own endpoint for this test.