### PR TITLE
FISH-8086 - fix http2 test

### DIFF
--- a/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
+++ b/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
@@ -58,7 +58,7 @@ public class Http2Test {
      */
     @Test(timeout = 10000L)
     public void testHttp2ControlGroup() throws Exception {
-        testHttp2(new URI("https://http2.akamai.com/"));
+        testHttp2(new URI("https://linkedin.com/"));
     }
 
     /**


### PR DESCRIPTION
the http2 test was pointing at https://http2.akamai.com/ expecting a response using the http2 protocol. It doesn't respond with http2 anymore, so I'm changing the target to https://linkedin.com until we have our own endpoint for this test.