### PR TITLE
FISH-10631 Re enable Security JWT test

### DIFF
--- a/security/pom.xml
+++ b/security/pom.xml
@@ -14,8 +14,7 @@
 
     <modules>
         <module>dynamic-rememberme</module>
-        <!-- FISH-11628 Disabled temporarily
-        <module>jwt</module>-->
+        <module>jwt</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
Run `mvn clean verify -Ppayara-server-managed -Dpayara.version=7.2025.1.Beta2-SNAPSHOT -pl . -pl test-utils -pl security/ -pl security/jwt/`

See
```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.922 s - in org.javaee8.security.jwt.JwtTest
Stopping container using command: [/Users/kalinchan/.sdkman/candidates/java/current/bin/java, -jar, /Users/kalinchan/workspace/patched-src-javaee8-samples/target/payara7/glassfish/modules/admin-cli.jar, stop-domain, domain1, -t]
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```